### PR TITLE
Extend scalar inputs in dotproducts to vec3

### DIFF
--- a/hw/xbox/nv2a_psh.c
+++ b/hw/xbox/nv2a_psh.c
@@ -414,7 +414,7 @@ static void add_stage_code(struct PixelShader *ps,
 
     QString *ab;
     if (output.ab_op == PS_COMBINEROUTPUT_AB_DOT_PRODUCT) {
-        ab = qstring_from_fmt("dot(%s, %s)",
+        ab = qstring_from_fmt("dot(vec3(%s), vec3(%s))",
                               qstring_get_str(a), qstring_get_str(b));
     } else {
         ab = qstring_from_fmt("(%s * %s)",
@@ -423,7 +423,7 @@ static void add_stage_code(struct PixelShader *ps,
 
     QString *cd;
     if (output.cd_op == PS_COMBINEROUTPUT_CD_DOT_PRODUCT) {
-        cd = qstring_from_fmt("dot(%s, %s)",
+        cd = qstring_from_fmt("dot(vec3(%s), vec3(%s))",
                               qstring_get_str(c), qstring_get_str(d));
     } else {
         cd = qstring_from_fmt("(%s * %s)",


### PR DESCRIPTION
Mace Griffin Bounty Hunter seems to do: `r1.rgb = vec3(dot(r0.rgb, r0.a));`

I'm not sure what exactly this does. I believe the dotproduct is only valid for rgb channels. We should probably hw-test this.

(Not upstream because this is a hack to get the game working further, needs hw testing)