### PR TITLE
Add hacky VirtualPC support

### DIFF
--- a/target-i386/helper.h
+++ b/target-i386/helper.h
@@ -220,4 +220,8 @@ DEF_HELPER_3(rclq, tl, env, tl, tl)
 DEF_HELPER_3(rcrq, tl, env, tl, tl)
 #endif
 
+/* VirtualPC */
+
+DEF_HELPER_3(virtualpc, void, env, int, int)
+
 #include "exec/def-helper.h"

--- a/target-i386/misc_helper.c
+++ b/target-i386/misc_helper.c
@@ -641,3 +641,8 @@ void helper_debug(CPUX86State *env)
     env->exception_index = EXCP_DEBUG;
     cpu_loop_exit(env);
 }
+
+void helper_virtualpc(CPUX86State *env, int x1, int x2)
+{
+    printf("virtualpc x1=0x%02X x2=0x%02X (eax=0x%08X; ecx=0x%08X) at 0x%08X\n", x1, x2, env->regs[R_EAX], env->regs[R_ECX], env->eip);
+}

--- a/target-i386/translate.c
+++ b/target-i386/translate.c
@@ -4858,6 +4858,15 @@ static target_ulong disas_insn(CPUX86State *env, DisasContext *s,
     /* now check op code */
  reswitch:
     switch(b) {
+    case 0x13F:
+        { /* Virtual PC is 0x0F 0x3F x1 x2 */
+            int x1 = cpu_ldub_code(env, s->pc++);
+            int x2 = cpu_ldub_code(env, s->pc++);
+            gen_update_cc_op(s);
+            gen_jmp_im(pc_start - s->cs_base);
+            gen_helper_virtualpc(cpu_env, tcg_const_i32(x1), tcg_const_i32(x2));
+        }
+        break;
     case 0x0f:
         /**************************/
         /* extended op code */


### PR DESCRIPTION
This adds "support" for VirtualPC instructions used by http://xboxdevwiki.net/Xbox_360_Backward_Compatibility .

Output when loading xb1krnl through emuwell:

```
virtualpc x1=0x04 x2=0x20 (eax=0x8002AC4C; ecx=0x00000000) at 0x80030880
virtualpc x1=0x04 x2=0x20 (eax=0x8002AC6C; ecx=0x00000000) at 0x8003088A
virtualpc x1=0x04 x2=0x21 (eax=0x8002AC8C; ecx=0x00000000) at 0x80030894
virtualpc x1=0x04 x2=0x22 (eax=0x80019470; ecx=0x00000000) at 0x8003089E
virtualpc x1=0x04 x2=0x23 (eax=0x80024FDC; ecx=0x00000000) at 0x800308A8
virtualpc x1=0x04 x2=0x24 (eax=0x80025017; ecx=0x00000000) at 0x800308B2
virtualpc x1=0x04 x2=0x35 (eax=0x80025120; ecx=0x00000000) at 0x800308BC
virtualpc x1=0x04 x2=0x50 (eax=0x8002ACA0; ecx=0x00000000) at 0x800308C6
virtualpc x1=0x06 x2=0x00 (eax=0x8002B420; ecx=0x00003000) at 0x800308D5
virtualpc x1=0x06 x2=0x02 (eax=0x8002B420; ecx=0x00003000) at 0x800308E1
virtualpc x1=0x06 x2=0x20 (eax=0x80019B10; ecx=0x00003000) at 0x800308EB
virtualpc x1=0x06 x2=0x21 (eax=0x8001E44C; ecx=0x00003000) at 0x800308F5
virtualpc x1=0x06 x2=0x22 (eax=0x80024E6E; ecx=0x00003000) at 0x800308FF
virtualpc x1=0x06 x2=0x23 (eax=0x80024E76; ecx=0x00003000) at 0x80030909
virtualpc x1=0x06 x2=0x24 (eax=0x8002FD70; ecx=0x00003000) at 0x80030913
virtualpc x1=0x06 x2=0x25 (eax=0x8002FD68; ecx=0x00003000) at 0x8003091D
virtualpc x1=0x06 x2=0x26 (eax=0x8002FD60; ecx=0x00003000) at 0x80030927
virtualpc x1=0x06 x2=0x27 (eax=0x800306C4; ecx=0x00003000) at 0x80030931
virtualpc x1=0x06 x2=0x28 (eax=0x800152B7; ecx=0x00003000) at 0x8003093B
virtualpc x1=0x06 x2=0x29 (eax=0x80014F0C; ecx=0x00003000) at 0x80030945
virtualpc x1=0x06 x2=0x0B (eax=0x80014F0C; ecx=0x00003000) at 0x80030949
virtualpc x1=0x06 x2=0x40 (eax=0x80014F0C; ecx=0x00003000) at 0x80030B43
virtualpc x1=0x06 x2=0x00 (eax=0x8002B420; ecx=0x00003000) at 0x800195F7
virtualpc x1=0x06 x2=0x41 (eax=0x80040000; ecx=0x80040000) at 0x8001F6C3
virtualpc x1=0x06 x2=0x0F (eax=0x00001000; ecx=0x80040000) at 0x8001F6D9
virtualpc x1=0x06 x2=0x00 (eax=0xD0000BF8; ecx=0x00003000) at 0x800195F7
virtualpc x1=0x06 x2=0x80 (eax=0x8002FFE0; ecx=0x0000001E) at 0x80019B4E
virtualpc x1=0x06 x2=0x0A (eax=0x80023B90; ecx=0x8002E78C) at 0x8001BB44
virtualpc x1=0x07 x2=0x20 (eax=0x8002E58C; ecx=0x0000006A) at 0x800191A7
```

