### PR TITLE
APU Threads

### DIFF
--- a/hw/xbox/dsp/dsp.c
+++ b/hw/xbox/dsp/dsp.c
@@ -149,6 +149,8 @@ void dsp_step(DSPState* dsp)
     dsp56k_execute_instruction(&dsp->core);
 }
 
+int foodebug = 0;
+
 void dsp_run(DSPState* dsp, int cycles)
 {
     dsp->save_cycles += cycles;
@@ -166,6 +168,9 @@ void dsp_run(DSPState* dsp, int cycles)
     //  printf("--> %d\n", dsp->core.save_cycles);
     while (dsp->save_cycles > 0)
     {
+if (foodebug) {
+        printf("%d cycles remaining\n", dsp->save_cycles);
+}
         dsp56k_execute_instruction(&dsp->core);
         dsp->save_cycles -= dsp->core.instr_cycle;
     }

--- a/hw/xbox/dsp/dsp_cpu.c
+++ b/hw/xbox/dsp/dsp_cpu.c
@@ -28,7 +28,7 @@
 
 #include "dsp_cpu.h"
 
-#define TRACE_DSP_DISASM 0
+int TRACE_DSP_DISASM = 0;
 #define TRACE_DSP_DISASM_REG 0
 #define TRACE_DSP_DISASM_MEM 0
 


### PR DESCRIPTION
This uses a pipeline from VP -> MIXBUF -> GP -> Scratch -> EP.
It also improves timing of the SE to get closer to the 48000 Hz which are required to stay in sync with the AC97.

The VP -> GP sync is handled by the VP operating on a temporary output mixbuffer. Only once the GP thread is idle, the temporary VP mixbuffer will be moved to the real GP MIXBUF input. The GP is then kicked off after the copy.

Preprocessor var `SYNC_GP_EP` will indicate wether GP -> EP needs to be synchronized (= will GP have to wait for EP to be idle before starting). Assuming a ringbuffer is used between GP and EP, we don't have to sync here. Consider this change experimental. - More hardware tests are necessary.