### PR TITLE
Handle AC97 reg access of all sizes

### DIFF
--- a/hw/audio/ac97.c
+++ b/hw/audio/ac97.c
@@ -818,7 +818,7 @@ static uint32_t nabm_readl (void *opaque, uint32_t addr)
  * Native audio bus master
  * I/O Writes
  */
-static void nabm_writeb (void *opaque, uint32_t addr, uint32_t val)
+static bool nabm_try_writeb(void *opaque, uint32_t addr, uint32_t val)
 {
     AC97LinkState *s = opaque;
     AC97BusMasterRegs *r = NULL;
@@ -872,12 +872,13 @@ static void nabm_writeb (void *opaque, uint32_t addr, uint32_t val)
         dolog ("SR[%d] <- %#x (sr %#x)\n", GET_BM (index), val, r->sr);
         break;
     default:
-        dolog ("U nabm writeb %#x <- %#x\n", addr, val);
-        break;
+        return false;
     }
+    dolog ("S nabm writeb %#x <- %#x\n", addr, val);
+    return true;
 }
 
-static void nabm_writew (void *opaque, uint32_t addr, uint32_t val)
+static bool nabm_try_writew (void *opaque, uint32_t addr, uint32_t val)
 {
     AC97LinkState *s = opaque;
     AC97BusMasterRegs *r = NULL;
@@ -893,16 +894,18 @@ static void nabm_writew (void *opaque, uint32_t addr, uint32_t val)
         dolog ("SR[%d] <- %#x (sr %#x)\n", GET_BM (index), val, r->sr);
         break;
     default:
-        dolog ("U nabm writew %#x <- %#x\n", addr, val);
-        break;
+        return false;
     }
+    dolog ("S nabm writew %#x <- %#x\n", addr, val);
+    return true;
 }
 
-static void nabm_writel (void *opaque, uint32_t addr, uint32_t val)
+static bool nabm_try_writel (void *opaque, uint32_t addr, uint32_t val)
 {
     AC97LinkState *s = opaque;
     AC97BusMasterRegs *r = NULL;
     uint32_t index = addr;
+
     switch (index) {
     case PI_BDBAR:
     case PO_BDBAR:
@@ -928,9 +931,10 @@ static void nabm_writel (void *opaque, uint32_t addr, uint32_t val)
         dolog ("glob_sta <- %#x (glob_sta %#x)\n", val, s->glob_sta);
         break;
     default:
-        dolog ("U nabm writel %#x <- %#x\n", addr, val);
-        break;
+        return false;
     }
+    dolog ("S nabm writel %#x <- %#x\n", addr, val);
+    return true;
 }
 
 static int write_audio (AC97LinkState *s, AC97BusMasterRegs *r,
@@ -1238,16 +1242,23 @@ static void nabm_write(void *opaque, hwaddr addr, uint64_t val,
 {
     dolog("nabm_write [0x%llx] = 0x%llx (%d)\n", addr, val, size);
 
-    switch (size) {
-    case 1:
-        nabm_writeb(opaque, addr, val);
-        break;
-    case 2:
-        nabm_writew(opaque, addr, val);
-        break;
-    case 4:
-        nabm_writel(opaque, addr, val);
-        break;
+    while(size > 0) {
+      if ((size >= 4) && nabm_try_writel(opaque, addr, val)) {
+        size -= 4;
+        addr += 4;
+        val >>= 4 * 8;
+        continue;
+      }
+      if ((size >= 2) && nabm_try_writew(opaque, addr, val)) {
+        size -= 2;
+        addr += 2;
+        val >>= 2 * 8;
+        continue;
+      }
+      nabm_try_writeb(opaque, addr, val);
+      size -= 1;
+      addr += 1;
+      val >>= 1 * 8;
     }
 }
 


### PR DESCRIPTION
Fixes AC97 output with OpenXDK XAudio.

QEMU does not handle 16 bit writes to two neighbouring 8 bit registers (and similar combinations).
The fix is still not ideal; I'm thinking this might be more complicated internally (= what happens when writing to the middle of a 32 bit register with 8 or 16 bit?). It will require further hardware testing.

---

TODO:

* Reword PR description
* Mention remaining AC97 issues
* Wait for nxdk-rdt to support unit test in xbox-tools (needs CALL and new memory functionality)